### PR TITLE
add methods for non-blocking backpressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,40 @@
 version = 3
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "mjpeg_rs"
-version = "0.1.0"
+version = "0.0.1"
+dependencies = [
+ "crossbeam-channel",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,11 @@ authors = ["oldcat <924417424@qq.com>"]
 edition = "2018"
 readme = "README.md"
 description = "rust编写的mjpeg服务器"
-categories = ["Web programming","Computer vision","Embedded development","Multimedia"]
+categories = ["Web programming", "Computer vision", "Embedded development", "Multimedia"]
 repository = "https://github.com/t924417424/mjpeg_rs"
 homepage = "https://github.com/t924417424/mjpeg_rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+crossbeam-channel = "0.5.1"


### PR DESCRIPTION
Hi. I found this crate on crates.io and it inspired me to use it in my computer vision debugging prototype. I really like the simple API. It is great for debugging.

This pull request adds two methods:

try_update_jpeg()
is_full()

This requires switching to crossbeam-channel.

My proof-of-concept lives here: https://github.com/alsuren/robokite/pull/1 and discussions are happening on discord at https://discord.gg/d32jaam

Outstanding issues:

- [x] is it okay to encode 1 extra frame before blocking for your use-case?
- [x] should we make our own error types for the TrySendError and SendError types, to avoid tying ourselves to crossbeam-channel?